### PR TITLE
Add Dependabot configuration for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering the npm ecosystem (the only package ecosystem in this repo)
- Weekly schedule with grouped updates for production and development dependencies
- Open PR limit of 10

## Audit findings
- No `.github` directory or Dependabot config existed prior to this PR
- No GitHub Actions workflows exist, so `github-actions` ecosystem coverage is not applicable
- No uv/pip ecosystem detected (Node/TypeScript project only)

## Test plan
- [ ] Verify Dependabot begins creating PRs after merge
- [ ] Confirm grouping works as expected (production vs development)

Generated with [Claude Code](https://claude.com/claude-code)